### PR TITLE
Updated codebase to ark-*v.0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,13 @@ license = "MIT/Apache-2.0"
 edition = "2021"
 
 [workspace.dependencies]
+ark-algebra-test-templates = { version = "0.5.0", default-features = false }
+ark-bn254 = { version = "0.5.0", default-features = false, features = ["curve"] }
 ark-ec = { version = "0.5.0", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
-ark-std = { version = "0.5.0", default-features = false }
-ark-serialize = { version = "0.5.0", default-features = false, features = ["derive"] }
-ark-bn254 = { version = "0.5.0", default-features = false, features = ["curve"] }
-ark-scale = { version = "0.0.13", default-features = false, features = ["hazmat"] }
-ark-algebra-test-templates = { version = "0.5.0", default-features = false }
-
 ark-models-ext = { path = "./models", version = "0.5.0", default-features = false }
-test-utils = { path = "./test-utils", default-features = false }
-
+ark-serialize = { version = "0.5.0", default-features = false, features = ["derive"] }
+ark-scale = { version = "0.0.13", default-features = false, features = ["hazmat"] }
+ark-std = { version = "0.5.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+test-utils = { path = "./test-utils", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,6 @@ ark-models-ext = { path = "./models", version = "0.5.0", default-features = fals
 ark-serialize = { version = "0.5.0", default-features = false, features = ["derive"] }
 ark-scale = { version = "0.0.13", default-features = false, features = ["hazmat"] }
 ark-std = { version = "0.5.0", default-features = false }
+educe = { version = "0.6.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 test-utils = { path = "./test-utils", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Horizen Labs <admin@horizenlabs.io>"]
 repository = "https://github.com/zkVerify/accelerated-bn-cryptography"
 homepage = "https://horizenlabs.io"
@@ -18,16 +18,15 @@ license = "MIT/Apache-2.0"
 edition = "2021"
 
 [workspace.dependencies]
-ark-ec = { version = "0.4.0", default-features = false }
-ark-ff = { version = "0.4.0", default-features = false }
-ark-std = { version = "0.4.0", default-features = false }
-ark-serialize = { version = "0.4.0", default-features = false, features = ["derive"] }
-ark-bn254 = { version = "0.4.0", default-features = false, features = ["curve"] }
-ark-scale = { version = "0.0.12", default-features = false, features = ["hazmat"] }
-ark-algebra-test-templates = { version = "0.4.2", default-features = false }
+ark-ec = { version = "0.5.0", default-features = false }
+ark-ff = { version = "0.5.0", default-features = false }
+ark-std = { version = "0.5.0", default-features = false }
+ark-serialize = { version = "0.5.0", default-features = false, features = ["derive"] }
+ark-bn254 = { version = "0.5.0", default-features = false, features = ["curve"] }
+ark-scale = { version = "0.0.13", default-features = false, features = ["hazmat"] }
+ark-algebra-test-templates = { version = "0.5.0", default-features = false }
 
-ark-models-ext = { path = "./models", version = "0.4.0", default-features = false }
+ark-models-ext = { path = "./models", version = "0.5.0", default-features = false }
 test-utils = { path = "./test-utils", default-features = false }
 
-derivative = { version = "2.2", default-features = false, features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -16,8 +16,6 @@ ark-ec.workspace = true
 ark-std.workspace = true
 ark-serialize.workspace = true
 
-derivative.workspace = true
-
 [features]
 default = [ "std" ]
 std = [ "ark-ff/std", "ark-serialize/std", "ark-std/std" ]

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -15,6 +15,7 @@ ark-ff.workspace = true
 ark-ec.workspace = true
 ark-std.workspace = true
 ark-serialize.workspace = true
+educe.workspace = true
 
 [features]
 default = [ "std" ]

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -15,13 +15,10 @@
 // limitations under the License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// Temporary fix to make clippy happy with implementation of clone on copy types
-// provided by "derivative" crate.
-#![allow(clippy::non_canonical_clone_impl)]
 
 pub use ark_ec::{
-    scalar_mul, scalar_mul::*, twisted_edwards, twisted_edwards::*, AffineRepr, CurveGroup, Group,
-    VariableBaseMSM,
+    scalar_mul, scalar_mul::*, twisted_edwards, twisted_edwards::*, AffineRepr, CurveGroup,
+    PrimeGroup, VariableBaseMSM,
 };
 pub mod models;
 pub use models::*;

--- a/models/src/models/bn/g1.rs
+++ b/models/src/models/bn/g1.rs
@@ -28,7 +28,7 @@ pub type G1Projective<P> = Projective<<P as BnConfig>::G1Config>;
 
 #[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
 #[educe(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct G1Prepared<P: BnConfig>(pub G1Affine<P>)
+pub struct G1Prepared<P>(pub G1Affine<P>)
 where
     P: BnConfig;
 

--- a/models/src/models/bn/g1.rs
+++ b/models/src/models/bn/g1.rs
@@ -21,35 +21,16 @@ use crate::models::{
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
-use core::fmt;
+use educe::Educe;
 
 pub type G1Affine<P> = Affine<<P as BnConfig>::G1Config>;
 pub type G1Projective<P> = Projective<<P as BnConfig>::G1Config>;
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct G1Prepared<P: BnConfig>(pub G1Affine<P>);
-
-impl<P: BnConfig> Copy for G1Prepared<P> {}
-
-impl<P: BnConfig> Clone for G1Prepared<P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<P: BnConfig> PartialEq for G1Prepared<P> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<P: BnConfig> Eq for G1Prepared<P> {}
-
-impl<P: BnConfig> fmt::Debug for G1Prepared<P> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("G1Prepared").field(&self.0).finish()
-    }
-}
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct G1Prepared<P: BnConfig>(pub G1Affine<P>)
+where
+    P: BnConfig;
 
 impl<P: BnConfig> From<G1Affine<P>> for G1Prepared<P> {
     fn from(other: G1Affine<P>) -> Self {

--- a/models/src/models/bn/g1.rs
+++ b/models/src/models/bn/g1.rs
@@ -19,22 +19,37 @@ use crate::models::{
     short_weierstrass::{Affine, Projective},
 };
 use ark_ec::{AffineRepr, CurveGroup};
-use ark_serialize::*;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
-use derivative::Derivative;
+use core::fmt;
 
 pub type G1Affine<P> = Affine<<P as BnConfig>::G1Config>;
 pub type G1Projective<P> = Projective<<P as BnConfig>::G1Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Copy(bound = "P: BnConfig"),
-    Clone(bound = "P: BnConfig"),
-    PartialEq(bound = "P: BnConfig"),
-    Eq(bound = "P: BnConfig"),
-    Debug(bound = "P: BnConfig")
-)]
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct G1Prepared<P: BnConfig>(pub G1Affine<P>);
+
+impl<P: BnConfig> Copy for G1Prepared<P> {}
+
+impl<P: BnConfig> Clone for G1Prepared<P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<P: BnConfig> PartialEq for G1Prepared<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<P: BnConfig> Eq for G1Prepared<P> {}
+
+impl<P: BnConfig> fmt::Debug for G1Prepared<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("G1Prepared").field(&self.0).finish()
+    }
+}
 
 impl<P: BnConfig> From<G1Affine<P>> for G1Prepared<P> {
     fn from(other: G1Affine<P>) -> Self {

--- a/models/src/models/bn/g2.rs
+++ b/models/src/models/bn/g2.rs
@@ -21,35 +21,16 @@ use crate::models::{
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
-use core::fmt;
+use educe::Educe;
 
 pub type G2Affine<P> = Affine<<P as BnConfig>::G2Config>;
 pub type G2Projective<P> = Projective<<P as BnConfig>::G2Config>;
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct G2Prepared<P: BnConfig>(pub G2Affine<P>);
-
-impl<P: BnConfig> Copy for G2Prepared<P> {}
-
-impl<P: BnConfig> Clone for G2Prepared<P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<P: BnConfig> PartialEq for G2Prepared<P> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<P: BnConfig> Eq for G2Prepared<P> {}
-
-impl<P: BnConfig> fmt::Debug for G2Prepared<P> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("G2Prepared").field(&self.0).finish()
-    }
-}
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct G2Prepared<P: BnConfig>(pub G2Affine<P>)
+where
+    P: BnConfig;
 
 impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
     fn from(other: G2Affine<P>) -> Self {

--- a/models/src/models/bn/g2.rs
+++ b/models/src/models/bn/g2.rs
@@ -28,7 +28,7 @@ pub type G2Projective<P> = Projective<<P as BnConfig>::G2Config>;
 
 #[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
 #[educe(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct G2Prepared<P: BnConfig>(pub G2Affine<P>)
+pub struct G2Prepared<P>(pub G2Affine<P>)
 where
     P: BnConfig;
 

--- a/models/src/models/bn/g2.rs
+++ b/models/src/models/bn/g2.rs
@@ -19,22 +19,37 @@ use crate::models::{
     short_weierstrass::{Affine, Projective},
 };
 use ark_ec::{AffineRepr, CurveGroup};
-use ark_serialize::*;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
-use derivative::Derivative;
+use core::fmt;
 
 pub type G2Affine<P> = Affine<<P as BnConfig>::G2Config>;
 pub type G2Projective<P> = Projective<<P as BnConfig>::G2Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Copy(bound = "P: BnConfig"),
-    Clone(bound = "P: BnConfig"),
-    PartialEq(bound = "P: BnConfig"),
-    Eq(bound = "P: BnConfig"),
-    Debug(bound = "P: BnConfig")
-)]
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct G2Prepared<P: BnConfig>(pub G2Affine<P>);
+
+impl<P: BnConfig> Copy for G2Prepared<P> {}
+
+impl<P: BnConfig> Clone for G2Prepared<P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<P: BnConfig> PartialEq for G2Prepared<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<P: BnConfig> Eq for G2Prepared<P> {}
+
+impl<P: BnConfig> fmt::Debug for G2Prepared<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("G2Prepared").field(&self.0).finish()
+    }
+}
 
 impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
     fn from(other: G2Affine<P>) -> Self {

--- a/models/src/models/bn/mod.rs
+++ b/models/src/models/bn/mod.rs
@@ -75,7 +75,7 @@ pub use self::{
 
 #[derive(Educe)]
 #[educe(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Bn<P: BnConfig>(PhantomData<fn() -> P>)
+pub struct Bn<P>(PhantomData<fn() -> P>)
 where
     P: BnConfig;
 

--- a/models/src/models/bn/mod.rs
+++ b/models/src/models/bn/mod.rs
@@ -30,14 +30,13 @@ use ark_ff::{
     PrimeField,
 };
 use ark_std::marker::PhantomData;
-use core::{
-    fmt,
-    hash::{Hash, Hasher},
-};
+use core::hash::{Hash, Hasher};
+use educe::Educe;
 
 pub trait BnConfig: 'static + Sized {
     /// Parameterizes the BN family.
     const X: &'static [u64];
+
     /// Whether or not `X` is negative.
     const X_IS_NEGATIVE: bool;
 
@@ -74,29 +73,11 @@ pub use self::{
     g2::{G2Affine, G2Prepared, G2Projective},
 };
 
-pub struct Bn<P: BnConfig>(PhantomData<fn() -> P>);
-
-impl<P: BnConfig> Copy for Bn<P> {}
-
-impl<P: BnConfig> Clone for Bn<P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<P: BnConfig> PartialEq for Bn<P> {
-    fn eq(&self, _: &Self) -> bool {
-        true
-    }
-}
-
-impl<P: BnConfig> Eq for Bn<P> {}
-
-impl<P: BnConfig> fmt::Debug for Bn<P> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Bn").finish()
-    }
-}
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Bn<P: BnConfig>(PhantomData<fn() -> P>)
+where
+    P: BnConfig;
 
 impl<P: BnConfig> Hash for Bn<P> {
     fn hash<H: Hasher>(&self, _state: &mut H) {}

--- a/models/src/models/bn/mod.rs
+++ b/models/src/models/bn/mod.rs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::models::short_weierstrass::SWCurveConfig;
 pub use ark_ec::models::bn::TwistType;
 use ark_ec::{
     models::CurveConfig,
@@ -29,9 +30,10 @@ use ark_ff::{
     PrimeField,
 };
 use ark_std::marker::PhantomData;
-use derivative::Derivative;
-
-use crate::models::short_weierstrass::SWCurveConfig;
+use core::{
+    fmt,
+    hash::{Hash, Hasher},
+};
 
 pub trait BnConfig: 'static + Sized {
     /// Parameterizes the BN family.
@@ -72,9 +74,33 @@ pub use self::{
     g2::{G2Affine, G2Prepared, G2Projective},
 };
 
-#[derive(Derivative)]
-#[derivative(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Bn<P: BnConfig>(PhantomData<fn() -> P>);
+
+impl<P: BnConfig> Copy for Bn<P> {}
+
+impl<P: BnConfig> Clone for Bn<P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<P: BnConfig> PartialEq for Bn<P> {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl<P: BnConfig> Eq for Bn<P> {}
+
+impl<P: BnConfig> fmt::Debug for Bn<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Bn").finish()
+    }
+}
+
+impl<P: BnConfig> Hash for Bn<P> {
+    fn hash<H: Hasher>(&self, _state: &mut H) {}
+}
 
 impl<P: BnConfig> Pairing for Bn<P> {
     type BaseField = <P::G1Config as CurveConfig>::BaseField;


### PR DESCRIPTION
This PR updates the code base to rely on the latest Arkworks crates (v.0.5.0) and is part of [ZKV-789](https://horizenlabs.atlassian.net/browse/ZKV-789?atlOrigin=eyJpIjoiYTVhOTdhOTY4MTUzNDEzN2JkOTZjNzkzZTViMzkwMDkiLCJwIjoiaiJ9). This decouples our code from the no longer maintained `derivative` crate. The primary references used for porting the code can be found below:

- [derivative documentation](https://mcarton.github.io/rust-derivative/latest/index.html)
- [ark-ec (v.0.5.0)](https://docs.rs/ark-ec/0.5.0/ark_ec/)