### PR TITLE
Accelerate tests on dev and other CI improvments

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = []
+
+[output]
+deny = ["unsound", "unmaintained", "yanked"]
+quiet = false
+show_tree = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -81,8 +81,15 @@ description = "Generate code coverage report"
 command = "cargo"
 args = ["llvm-cov", "--workspace", "--lcov", "--output-path", "lcov.info"]
 
+[tasks.udeps-minimal]
+description = "Check for unused dependencies in the project without any features"
+command = "cargo"
+toolchain = "nightly"
+args = ["udeps", "--all-targets", "--no-default-features"]
+
 [tasks.udeps]
 description = "Check for unused dependencies in the project"
+dependencies = ["udeps-minimal"]
 command = "cargo"
 toolchain = "nightly"
 args = ["udeps", "--all-targets"]

--- a/curves/bn254/build.rs
+++ b/curves/bn254/build.rs
@@ -1,0 +1,3 @@
+pub fn main() {
+    println!("cargo::rerun-if-env-changed=FAST_TESTS");
+}

--- a/curves/bn254/src/curves/tests.rs
+++ b/curves/bn254/src/curves/tests.rs
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(test)]
+
 use crate::CurveHooks;
 use ark_algebra_test_templates::*;
 use ark_bn254::{g1::Config as ArkG1Config, g2::Config as ArkG2Config, Bn254 as ArkBn254};
@@ -70,7 +72,17 @@ impl CurveHooks for TestHooks {
     }
 }
 
-test_group!(g1; G1Projective; sw);
-test_group!(g2; G2Projective; sw);
-test_group!(pairing_output; PairingOutput<Bn254>; msm);
+#[cfg(not(feature = "std"))]
+extern crate std;
+
+const fn iterations() -> usize {
+    match std::option_env!("FAST_TESTS") {
+        Some(_) => 2,
+        _ => 500,
+    }
+}
+
+test_group!(iterations(); g1; G1Projective; sw);
+test_group!(iterations(); g2; G2Projective; sw);
+test_group!(iterations(); pairing_output; PairingOutput<Bn254>; msm);
 test_pairing!(pairing; crate::Bn254<super::TestHooks>);


### PR DESCRIPTION
Accelerate tests via env variable: If you define `FAST_TEST` env when compile drastically reduce the number of iterations.

Configure cargo audit to not ignore unmaintained crates.
Check `udeps` with both all features and no features

Example of fast test:

`FAST_TESTS=1 cargo make ci`